### PR TITLE
Add warning note for Firefox users

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,8 @@ Learn more about machine learning by building a simple image classifier. For mor
 ## Built With
 
 - https://pytorch.org/tutorials/beginner/blitz/cifar10_tutorial.html
+
+## Warning
+
+If you're using Firefox Web Browser, you may encounter an issue saying `Error loading webview: Error: Could not register service workers: SecurityError: The operation is insecure..` while trying to load the Jupyter Notebook,
+so in order to properly load it, you'll need to disable Firefox's Enhanced Tracking Protection. More information at https://support.mozilla.org/en-US/kb/enhanced-tracking-protection-firefox-desktop.


### PR DESCRIPTION
This PR addresses an issue for Firefox users when trying to open a Jupyter Notebook through VSCode in GitHub Codespaces in the web browser, as by default Firefox has an option enabled for protection which is `Enhanced Tracking Protection` and the only way to open `.ipynb` files is to actually disable it. More information at https://support.mozilla.org/en-US/kb/enhanced-tracking-protection-firefox-desktop

Note: this is an existing issue that also occurs in GitPod as reported at https://github.com/gitpod-io/gitpod/issues/9386